### PR TITLE
Update Partners.tsx

### DIFF
--- a/src/components/Partners/Partners.tsx
+++ b/src/components/Partners/Partners.tsx
@@ -19,7 +19,7 @@ const partnerMap = [
   {
     img: Grove,
     name: "BTC Grove",
-    url: "https://twitter.com/BitcoinGrove",
+    url: "https://btcgrove.com",
   },
 ];
 


### PR DESCRIPTION
Changed link to btc grove.

Let's also use this image, wide (B&W) to match the other partner images (the square crop didn't match, especially on mobile view):

![image](https://github.com/Resolvr-io/osjf/assets/115094037/ecbaae8b-0e78-44ec-ab89-24c7d535f66a)

Asset in [figma](https://www.figma.com/file/rw4Tt59eZqIpaJ8UxntuLg/Resolvr-Designs?type=design&node-id=0%3A1&mode=design&t=FFEOHOPJaoJWfnNy-1).